### PR TITLE
Update advanced_list_configuration.json

### DIFF
--- a/samples/site-create-advanced-lists/advanced_list_configuration.json
+++ b/samples/site-create-advanced-lists/advanced_list_configuration.json
@@ -60,7 +60,7 @@
             "subactions": 
             [
                 {
-                    "verb": "SetDescription",
+                    "verb": "setDescription",
                     "description": "Custom document library to illustrate SharePoint site scripting capabilities - spring 2018"
                 },
                 {


### PR DESCRIPTION
Small typo. I don't know if the verbs are case sensitive? 

But when testing the above json script the description of my document library wasn't set. After changing the 'Set' to 'set' the script action worked.

| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New sample?      | no 
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Corrected a small typo in one of the subactions of the json file.