### PR TITLE
request body fix

### DIFF
--- a/samples/triggerFlow-write-back-site-properties-to-splist/request-body-json-schema.json
+++ b/samples/triggerFlow-write-back-site-properties-to-splist/request-body-json-schema.json
@@ -13,7 +13,7 @@
         "creatorEmail": {
             "type": "string"
         },
-        "creationTimeUTC": {
+        "createdTimeUTC": {
             "type": "string"
         },
         "parameters": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  YES
| New sample?      | NO
| Related issues?  | No

#### What's in this Pull Request?

I fixed the request-body-json-schema.json file, since the creation Date were not being passed to the flow. The file had a property with the wrong name, the property was named "creationTimeUTC" while the Readme file states that it should be named "createdTimeUTC

The change was tested on my dev tentant and confimed that works fine... the flow received the property after the fix